### PR TITLE
docs(audit): add full-spectrum crypto/security audit reports

### DIFF
--- a/audit/HIG-001-domain-separation-non-injective.md
+++ b/audit/HIG-001-domain-separation-non-injective.md
@@ -1,0 +1,100 @@
+# HIG-001: Domain Separation Is Non-Injective (Prefix Collision + Silent Truncation)
+
+### 1. Classification
+- Type: Cryptographic Misuse / Domain Separation Failure
+- CWE: CWE-347 (Improper Verification of Cryptographic Signature)
+- Severity: Critical
+- Exploitability: Practical
+
+---
+
+### 2. Affected Component
+- File(s):
+  - `src/pqc_crypto.c`
+  - `include/higgaion/pqc_crypto.h`
+  - (Claimed behavior in) `enterprise_gateway_deployment_guide.md`, `enterprise_gateway_client_implementation_guide.md`
+- Function(s): `pqc_sign`, `pqc_verify`
+- Layer: C core
+
+---
+
+### 3. Vulnerability Description
+Invariant claimed/required: **A signature bound to `(domain_separation_tag, message)` must not validate under any other `(domain', message')` unless both pairs are identical.**
+
+Actual behavior: the implementation computes `buffer = domain || message` with `dom_len = strnlen(domain, 4096)` and signs/verifies `buffer`. This mapping is **not injective**:
+- **Prefix collision**: `(d1, m1) ≠ (d2, m2)` can still produce the same concatenation (`d1||m1 = d2||m2`).
+- **Silent truncation**: any domain longer than 4096 bytes is effectively truncated to its first 4096 bytes, collapsing distinct domains to the same signed prefix.
+
+This is an implementation flaw with protocol-level consequences.
+
+---
+
+### 4. Root Cause Analysis
+- Missing unambiguous encoding (no length prefix, no delimiter with a stated forbidden set, no structured hashing).
+- Unsafe “safety” cap (`strnlen(..., 4096)`) that truncates rather than rejects overlong domains, creating equivalence classes of domains.
+
+---
+
+### 5. Attack Scenario
+- Initial state: A signing service signs requests for multiple domains (e.g., staging vs production).
+- Attacker capabilities: chosen-message queries in a low-impact domain; replay/manipulation of traffic.
+- Step-by-step:
+  1) Attacker requests a signature for domain `A` on message `BC`.
+  2) Attacker submits the signature to a verifier for domain `AB` on message `C`.
+  3) Verifier reconstructs `AB||C = ABC`, identical to the signed bytes, and accepts.
+- Resulting system violation: **cross-domain authorization bypass** even though “domain separation” is present.
+
+---
+
+### 6. Proof of Concept (PoC)
+Code-level PoC (C) demonstrating cross-domain validation via prefix collision (returns `TRUE` with current implementation):
+
+```c
+// Sign (domain="A", msg="BC"), verify (domain="AB", msg="C")
+const char *domain1="A";  const uint8_t msg1[]="BC";
+pqc_sign(&sig,&sig_len,msg1,2,domain1,&key);
+
+const char *domain2="AB"; const uint8_t msg2[]="C";
+bool ok = pqc_verify(msg2,1,sig,sig_len,domain2,&key); // ok == true
+```
+
+Also exploitable via truncation:
+- `domain2 = "A"*4096 + "B"` signs/verifies as if the domain were `"A"*4096`.
+
+---
+
+### 7. Impact Analysis
+- Confidentiality impact: indirect (cross-domain confusion can route signed actions to unintended trust zones).
+- Integrity violation: **signature accepted for wrong domain** (authorization boundary breach).
+- Authentication bypass: yes (domain is part of the authentication context per docs).
+- Replay / forgery / key compromise: enables **cross-domain replay** by construction.
+- Cross-domain contamination: direct.
+
+---
+
+### 8. Formal Security Impact
+- Invalidates: **Domain Separation** property (the core claim in gateway docs).
+- Does *not* break ML-DSA EUF-CMA as a primitive; it breaks the *scheme construction* used to bind domains.
+
+---
+
+### 9. Mitigation / Fix
+Concrete code-level fix (minimum):
+- Reject overlong domains rather than truncating:
+  - If `strnlen(domain, MAX) == MAX`, return error (treat as invalid/untrusted).
+- Make domain separation injective:
+  - Use length-prefix encoding: `len(domain)||domain||len(msg)||msg`
+  - Or sign a structured hash: `H = SHA3-256("HIG_DS_V1" || u32_be(len(domain)) || domain || u64_be(len(msg)) || msg)` and sign `H`.
+
+Protocol-level fix:
+- Specify domain tags as **byte strings with explicit length** and canonicalization rules.
+
+---
+
+### 10. Verification Strategy
+- Unit tests: include the exact collision cases:
+  - `("A","BC")` vs `("AB","C")` must fail.
+  - `("A"*4096, msg)` vs `("A"*4096+"B", msg)` must fail.
+- Property-based tests: generate `(d1,m1,d2,m2)` where encodings collide; verify rejection.
+- Differential fuzzing: fuzz domain/message encoding and compare against a reference encoding implementation.
+

--- a/audit/HIG-002-crypto-downgrade-algorithm-agility.md
+++ b/audit/HIG-002-crypto-downgrade-algorithm-agility.md
@@ -1,0 +1,101 @@
+# HIG-002: Cryptographic Downgrade Exposure (ED25519 Fallback + Unrestricted Algorithm Selection)
+
+### 1. Classification
+- Type: Cryptographic Misuse / Downgrade
+- CWE: CWE-757 (Selection of Less-Secure Algorithm During Negotiation)
+- Severity: High
+- Exploitability: Conditional
+
+---
+
+### 2. Affected Component
+- File(s):
+  - `src/pqc_crypto.c`
+  - `go/higgaion.go`
+  - `rust/src/lib.rs`
+  - `python/higgaion/core.py`
+  - `tests/test_pqc_crypto.c`
+  - `go/higgaion_test.go`
+  - `rust/tests/integration_tests.rs`
+  - `python/tests/test_crypto.py`
+  - `enterprise_gateway_deployment_guide.md`
+  - `enterprise_gateway_client_implementation_guide.md`
+- Function(s): `generate_keypair` (C), `GenerateKeypair` (Go/Python), `generate_keypair` (Rust)
+- Layer: C core + FFI + operational docs
+
+---
+
+### 3. Vulnerability Description
+Invariant required under a PQ adversary: **security must not silently reduce from PQ signatures to classical signatures**.
+
+Reality:
+- The core API accepts an arbitrary `alg_name` string.
+- The test suite and enterprise docs explicitly recommend/perform fallback to `ED25519` when ML-DSA-87 is unavailable.
+- This creates a real deployment failure mode where the system is believed to be PQC-authenticated but actually operates classically.
+
+This is a design + operational control flaw: policy is not enforced by the cryptographic boundary.
+
+---
+
+### 4. Root Cause Analysis
+- No allowlist or “policy lock” at the cryptographic boundary.
+- “Optional fallback” is normalized in tests/docs, increasing the chance it becomes production behavior.
+- No transcript-binding/attestation that ML-DSA-87 is in use.
+
+---
+
+### 5. Attack Scenario
+- Initial state: Gateway deployed on heterogeneous nodes; some lack ML-DSA providers.
+- Attacker capabilities: can trigger availability/compatibility edges (routing to older nodes, exploiting partial rollouts/partitions).
+- Step-by-step:
+  1) Operator deploys expecting `ML-DSA-87`.
+  2) A subset of nodes lacks ML-DSA support → system falls back to `ED25519` per documented “interim workaround.”
+  3) Attacker targets those nodes and leverages classical compromise (key theft) or the assumed nation-state capabilities to defeat classical assurances.
+- Resulting system violation: post-quantum security posture collapses to classical where downgrade is enabled.
+
+---
+
+### 6. Proof of Concept (PoC)
+Code-level PoC (Go): the library accepts ED25519 and performs signing/verification successfully:
+
+```go
+priv, pub, _ := higgaion.GenerateKeypair("ED25519")
+sig, _ := priv.Sign([]byte("msg"), "domain")
+ok := pub.Verify([]byte("msg"), sig, "domain") // ok == true
+```
+
+The repo’s own tests and enterprise docs treat this downgrade as acceptable under provider-missing conditions.
+
+---
+
+### 7. Impact Analysis
+- Confidentiality impact: indirect (authorization bypass enables data access).
+- Integrity violation: direct (attacker can authorize operations with non-PQ guarantees).
+- Authentication bypass: yes, under PQ threat model or classical key compromise.
+- Replay / forgery / key compromise: enabled against downgraded nodes.
+
+---
+
+### 8. Formal Security Impact
+- Invalidates: **quantum resistance claim** for the deployed system (security reduces to ED25519 where enabled).
+- Breaks any protocol-level claim that requires PQ signatures for authentication.
+
+---
+
+### 9. Mitigation / Fix
+- Code-level:
+  - Remove `alg_name` from production-facing APIs; provide fixed ML-DSA-87 functions.
+  - If algorithm agility is required, enforce an allowlist and refuse insecure algorithms by default.
+- Operational:
+  - Fail closed if ML-DSA-87 provider is missing (no fallback).
+  - Emit an explicit attestation/metric that ML-DSA-87 is active; treat non-PQC as incident.
+- Protocol-level:
+  - Bind algorithm choice into signed transcript and configuration, preventing silent downgrade.
+
+---
+
+### 10. Verification Strategy
+- Unit tests: ensure ED25519 is rejected in “PQC-required” builds/configs.
+- Integration tests: simulate missing provider; verify startup fails (not downgrades).
+- CI policy: require ML-DSA-87 availability on release targets; block “fallback” paths outside test builds.
+

--- a/audit/HIG-003-ffi-use-after-free-pointer-aliasing.md
+++ b/audit/HIG-003-ffi-use-after-free-pointer-aliasing.md
@@ -1,0 +1,94 @@
+# HIG-003: FFI Wrappers Are Not Memory-Safe (EVP_PKEY Pointer Aliasing → Use-After-Free / Double-Free)
+
+### 1. Classification
+- Type: Memory Safety / FFI Lifecycle Violation
+- CWE: CWE-416 (Use After Free)
+- Severity: High
+- Exploitability: Practical
+
+---
+
+### 2. Affected Component
+- File(s):
+  - `go/higgaion.go`
+  - `rust/src/lib.rs`
+  - `python/higgaion/core.py`
+- Function(s):
+  - Go: `GenerateKeypair`, `(*PrivateKey).Free`, `(*PublicKey).Verify`
+  - Rust: `generate_keypair`, `Drop for PrivateKey`, `PublicKey::verify`
+  - Python: `GenerateKeypair`, `PrivateKey.__del__`, `PublicKey.verify`
+- Layer: FFI
+
+---
+
+### 3. Vulnerability Description
+Invariant required: **safe-language wrappers must not expose UB through safe APIs**.
+
+Reality: wrappers set `pub.pkey = priv.pkey` (aliasing a single OpenSSL object) but only one side frees it.
+- If the private key is freed/dropped/GC’d while the public key remains referenced, the public key becomes a dangling pointer and verify becomes a UAF.
+- If both are ever freed, you get double-free.
+
+---
+
+### 4. Root Cause Analysis
+- Incorrect ownership model over a reference-counted OpenSSL object.
+- Missing `EVP_PKEY_up_ref` when creating the “public key” wrapper view.
+- Reliance on GC finalization ordering in Python, and implicit lifetime coupling in Rust/Go without encoding it in types.
+
+---
+
+### 5. Attack Scenario
+- Initial state: A service generates a keypair, signs once, then retains only a “public key” object for verification tasks.
+- Attacker capabilities: can trigger verification calls repeatedly (remote input).
+- Step-by-step:
+  1) Service signs, then drops private key (or Python GC collects it).
+  2) Attacker sends requests requiring verification.
+  3) Verification uses freed OpenSSL pointer → crash or systematic verification failure.
+- Resulting system violation: **remote DoS**; in worst case, memory corruption if heap shaping becomes viable.
+
+---
+
+### 6. Proof of Concept (PoC)
+C-level PoC mirroring wrapper behavior (alias pointer then free one side):
+
+```c
+pub.pkey = priv.pkey;
+higgaion_key_free(&priv);
+pqc_verify(..., &pub); // UAF
+```
+
+Observable impact: verification after freeing the private key fails unpredictably (e.g., `EVP_DigestVerifyInit` can fail due to the dangling key type/provider state).
+
+---
+
+### 7. Impact Analysis
+- Confidentiality impact: conditional (UAF can become memory disclosure if exploited).
+- Integrity violation: verification correctness becomes undefined.
+- Authentication bypass: conditional (UB can fail-open depending on manifestation).
+- Availability: practical crash/failure under load.
+
+---
+
+### 8. Formal Security Impact
+- Invalidates: “memory-safe FFI” claim; any reasoning about correctness that assumes sound wrappers.
+- Undermines authentication correctness (you cannot assume fail-closed when UB is present).
+
+---
+
+### 9. Mitigation / Fix
+- C core: expose a function to safely clone/up-ref keys, e.g. `higgaion_key_up_ref(dst, src)` calling `EVP_PKEY_up_ref`.
+- Wrappers:
+  - Go: up-ref when assigning `pub.inner.pkey`, add `(*PublicKey).Free`.
+  - Rust: up-ref; implement `Drop for PublicKey`.
+  - Python: up-ref; implement `PublicKey.__del__` with independent ownership.
+- Encode lifetime coupling: if you insist on aliasing, make `PublicKey` borrow from `PrivateKey` (Rust) rather than owning.
+
+---
+
+### 10. Verification Strategy
+- Add explicit tests:
+  - Public key verify must remain correct after private key is freed/dropped.
+  - Double-free must be impossible (or must be safe via refcounts).
+- Run sanitizers on Linux (`ASAN/UBSAN`) plus fuzz verification after forced frees.
+- Add Python stress tests for GC ordering (cyclic refs + forced collections).
+

--- a/audit/HIG-004-key-lifecycle-leak-regeneration-overwrite.md
+++ b/audit/HIG-004-key-lifecycle-leak-regeneration-overwrite.md
@@ -1,0 +1,83 @@
+# HIG-004: Key Lifecycle Leak in C Core (Regeneration Overwrites Pointer Without Freeing) + Key Material Persistence
+
+### 1. Classification
+- Type: Resource Management / Sensitive Data Lifetime
+- CWE: CWE-401 (Memory Leak), CWE-226 (Sensitive Information Uncleared Before Release)
+- Severity: High
+- Exploitability: Conditional
+
+---
+
+### 2. Affected Component
+- File(s): `src/pqc_crypto.c`
+- Function(s): `generate_keypair`
+- Layer: C core
+
+---
+
+### 3. Vulnerability Description
+Invariant required: **regenerating a key must not leak prior key objects; key material lifetime must be bounded**.
+
+Actual: `generate_keypair` sets `key->pkey = NULL` before generating a new key, without freeing an existing `EVP_PKEY*`. If `key->pkey` was previously non-NULL, the old pointer is lost and the old key object is leaked.
+
+Consequences:
+- unbounded memory growth under repeated rotations
+- old private key material remaining resident longer than intended
+
+---
+
+### 4. Root Cause Analysis
+- Missing precondition enforcement (`key->pkey` must be NULL) or missing safe replacement (`EVP_PKEY_free` old before overwrite).
+- No explicit secure-memory strategy; relying on allocator/free behavior is not a valid key destruction claim.
+
+---
+
+### 5. Attack Scenario
+- Initial state: service rotates keys periodically or on-demand.
+- Attacker capabilities: can trigger key regeneration (API calls, forced re-init loops, induced failure modes).
+- Step-by-step:
+  1) Attacker triggers repeated regeneration.
+  2) Each call leaks an `EVP_PKEY` and associated allocations.
+  3) Process hits memory limits → crash.
+- Resulting system violation: DoS; expanded window for secret extraction if any memory disclosure occurs later.
+
+---
+
+### 6. Proof of Concept (PoC)
+Pointer-loss PoC:
+
+```c
+void *first = key.pkey;
+generate_keypair(&key, "ML-DSA-87");
+void *second = key.pkey; // first != second => first key leaked
+```
+
+---
+
+### 7. Impact Analysis
+- Confidentiality impact: increases blast radius of memory disclosure.
+- Integrity violation: indirect.
+- Availability: practical under repeated regen (memory exhaustion).
+
+---
+
+### 8. Formal Security Impact
+- Breaks operational key lifecycle assumptions required for many security arguments (bounded exposure, timely destruction).
+- Does not directly falsify EUF-CMA of ML-DSA, but makes system-level “key destruction” claims non-credible.
+
+---
+
+### 9. Mitigation / Fix
+- Code-level:
+  - If `key->pkey != NULL`, call `EVP_PKEY_free(key->pkey)` before overwrite.
+  - Alternatively, reject regeneration unless `key->pkey == NULL` and return an error code.
+- API-level:
+  - Return `HigError` from `generate_keypair` and require callers to handle failure explicitly.
+
+---
+
+### 10. Verification Strategy
+- Add tests that regenerate keys repeatedly and confirm no leak (valgrind/leak sanitizer on Linux).
+- Add CBMC harnesses over the actual C code for “no lost pointer” invariants.
+- Allocation-failure injection testing (platform-appropriate).
+

--- a/audit/HIG-005-or-mode-hybrid-verification-downgrade.md
+++ b/audit/HIG-005-or-mode-hybrid-verification-downgrade.md
@@ -1,0 +1,85 @@
+# HIG-005: OR-Mode Hybrid Verification (As Specified) Is a Downgrade Oracle (Signature Stripping + Weakest-Link Security)
+
+### 1. Classification
+- Type: Protocol Design Flaw / Composition Risk
+- CWE: CWE-757 (Selection of Less-Secure Algorithm During Negotiation)
+- Severity: Critical
+- Exploitability: Conditional
+
+---
+
+### 2. Affected Component
+- File(s): `verification/coq/PQCMigration.v`
+- Function(s): `hybrid_verify_disjunctive`, `hybrid_verify_pqc_preferred`
+- Layer: Protocol logic / Coq proofs
+
+---
+
+### 3. Vulnerability Description
+Invariant required under a PQ adversary: **once PQC is available/required, acceptance must imply PQC verification** (or an explicit, attacker-uncontrollable compatibility mode).
+
+The OR-mode definition accepts if *either* classical or PQC signature verifies. That means:
+- An attacker can strip the PQC signature component in transit and still be accepted if classical verifies.
+- The effective security is at best the minimum of the component schemes (and under PQ threat, classical is the weak link).
+
+The Coq file proves OR-mode permissiveness; it does not prove downgrade resistance or any cryptographic property.
+
+---
+
+### 4. Root Cause Analysis
+- Design prioritizes “zero downtime” by permitting legacy acceptance without binding acceptance policy to a threat model boundary.
+- Missing invariants for downgrade/stripping resistance (e.g., “if PQC key exists, PQC signature must be present and valid”).
+- No transcript binding that makes “missing PQC component” unambiguously invalid.
+
+---
+
+### 5. Attack Scenario
+- Initial state: system in HYBRID; verifiers accept OR-mode.
+- Attacker capabilities: on-path manipulation; can delete or alter fields (PQC sig).
+- Step-by-step:
+  1) Client sends (classical_sig, pqc_sig).
+  2) Attacker removes pqc_sig.
+  3) Verifier accepts on classical_sig alone.
+  4) If attacker can forge classical signatures (quantum assumption or key compromise), attacker authenticates without PQC.
+- Resulting system violation: authentication bypass relative to PQ security goals.
+
+---
+
+### 6. Proof of Concept (PoC)
+Formal counterexample (directly from the model witness used to prove permissiveness):
+- `msg=0, csig=0, psig=1`
+- `classical_verify msg csig = true`
+- `pqc_verify_sig msg psig = false`
+- `hybrid_verify_disjunctive = true`
+
+This shows OR-mode acceptance does **not** imply PQC validity.
+
+---
+
+### 7. Impact Analysis
+- Confidentiality impact: full compromise if authorization gates rely on hybrid verification.
+- Integrity violation: forged actions accepted.
+- Authentication bypass: yes, under the stated threat model.
+
+---
+
+### 8. Formal Security Impact
+- Invalidates any claim of post-quantum authentication for the composed protocol while OR-mode is permitted.
+- Composition fails: the protocol’s EUF-CMA reduces to the weakest component; downgrade resistance not achieved.
+
+---
+
+### 9. Mitigation / Fix
+- Protocol redesign:
+  - Use AND-mode composite signatures for security-critical operations.
+  - If backward compatibility is required, make it **explicit and bounded** (separate endpoints / explicit opt-in / time-bound window).
+  - If “PQC-preferred” is used, do **not** allow attacker-controlled absence to trigger fallback when PQC is configured/required.
+- Implementation requirement (when code exists): require that HYBRID state messages include PQC signature and validate it; reject classical-only unless in explicit legacy mode.
+
+---
+
+### 10. Verification Strategy
+- Extend Coq/TLA model with an adversarial channel that can strip fields.
+- Prove a downgrade-resistance theorem: acceptance implies PQC validity once PQC key exists (outside explicit legacy).
+- Add test vectors where pqc_sig is missing/empty; must fail under PQ-required policy.
+

--- a/audit/HIG-006-proof-integrity-gap-and-vacuous-models.md
+++ b/audit/HIG-006-proof-integrity-gap-and-vacuous-models.md
@@ -1,0 +1,91 @@
+# HIG-006: Proof Integrity Failure (Vacuous Crypto Models + Spec/Implementation Divergence + Misstated Theorems)
+
+### 1. Classification
+- Type: Proof Gap / Assurance Failure
+- CWE: N/A (formal-methods assurance defect)
+- Severity: High
+- Exploitability: Practical
+
+---
+
+### 2. Affected Component
+- File(s):
+  - `verification/coq/HiggaionTypes.v`
+  - `verification/coq/PQCMigration.v`
+  - `verification/coq/Gateway.v`
+  - `verification/tla/pqc_crash_recovery.tla`
+  - `verification/tla/pqc_distributed.tla`
+  - `verification/framac/wp_pqc_wal.c`
+  - `verification/cbmc/cbmc_pqc_migration_actual.c`
+  - Documentation making verification claims: `README.md`, `REVIEW_GUIDE.md`, `linkedin_announcement.md`, `enterprise_gateway_deployment_guide.md`, `enterprise_gateway_client_implementation_guide.md`
+- Function(s): multiple (formal models); “mapping” comments to absent functions/files
+- Layer: Coq proofs / TLA specs / verification harnesses / docs
+
+---
+
+### 3. Vulnerability Description
+Invariant required for formal assurance: **proved theorems must correspond to the implementation that is shipped and deployed**.
+
+Findings:
+- The compiled C core in this repo is essentially `src/pqc_crypto.c`, yet the formal artifacts repeatedly “map to” nonexistent sources (e.g., `src/pqc_migration.c`, `src/consensus.c`, `src/shard_wal.c`). There is no refinement link.
+- “Cryptographic verification” is modeled as integer equality (`Nat.eqb`) in `verification/coq/PQCMigration.v`, which cannot justify any real cryptographic property.
+- Example of claim/theorem mismatch:
+  - “WAL Replay Idempotence” is proved as `wal_replay (wal_replay r log) [] = wal_replay r log`, which is not idempotence of replaying the WAL twice; it is a trivial empty-log property.
+
+This is an assurance defect that causes high-risk overconfidence.
+
+---
+
+### 4. Root Cause Analysis
+- No proof-to-implementation correspondence layer (no extraction used, no verified compilation, no trace refinement, no translation validation).
+- Toy models substituted for cryptographic semantics.
+- Documentation asserts stronger properties than the artifacts actually establish.
+
+---
+
+### 5. Attack Scenario
+- Initial state: deployment decisions are made based on “formally verified” claims.
+- Attacker capabilities: exploit real implementation flaws and operational misconfigurations.
+- Step-by-step:
+  1) Operators treat domain separation and hybrid verification as “mathematically assured.”
+  2) Attacker exploits real implementation weaknesses (e.g., domain-collision bypass, downgrade paths, FFI UAF).
+  3) Defender response is delayed because the assurance story is believed.
+- Resulting system violation: security posture is weaker than believed; controls fail silently.
+
+---
+
+### 6. Proof of Concept (PoC)
+Empirical contradiction to documented “mathematical rejection” of cross-domain replay:
+- The C core accepts cross-domain verification via prefix collisions (see HIG-001 PoC), while enterprise docs assert this is impossible.
+
+---
+
+### 7. Impact Analysis
+- Confidentiality/Integrity/Availability: downstream—depends on which false assurances were relied on.
+- Operational impact: invalid compliance and audit narratives; brittle incident handling.
+
+---
+
+### 8. Formal Security Impact
+- Invalidates any claimed end-to-end property for the deployed code (domain separation, crash recovery, migration irreversibility) absent a refinement proof.
+- No basis for claiming EUF-CMA/IND-CCA2/composition security for the *system* based on these artifacts.
+
+---
+
+### 9. Mitigation / Fix
+- Stop claiming implementation verification unless you ship the verified implementation and the correspondence proof.
+- Provide one of:
+  - Verified extraction used as the implementation (with tests comparing extracted vs C), or
+  - A formal refinement proof tying the C implementation to the Coq/TLA spec, or
+  - Verified compilation toolchain (CompCert/VST-style) for the relevant C code.
+- Replace toy crypto models with explicit assumptions and prove the properties that matter (downgrade resistance, domain separation injectivity, replay resistance at the protocol layer).
+
+---
+
+### 10. Verification Strategy
+- Add a “proof-to-code” gate in CI:
+  - fail if “maps to” file paths do not exist in the repo
+  - run trace refinement tests comparing C executions to extracted reference
+- Run CBMC/Frama-C on the *actual* sources, not stubs/copies.
+- Add adversarial models to TLA/Coq that include message injection/replay/stripping and prove invariants against them.
+

--- a/audit/HIG-007-erasure-before-wal-crash-semantics-gap.md
+++ b/audit/HIG-007-erasure-before-wal-crash-semantics-gap.md
@@ -1,0 +1,78 @@
+# HIG-007: Erasure-Before-WAL Is Not Formally Grounded in a Durable Recovery Model (State Oracle + Resurrection Risk)
+
+### 1. Classification
+- Type: State Machine Violation / Crash-Recovery Semantics Gap
+- CWE: CWE-841 (Improper Enforcement of Behavioral Workflow)
+- Severity: High
+- Exploitability: Conditional
+
+---
+
+### 2. Affected Component
+- File(s):
+  - `verification/tla/pqc_crash_recovery.tla`
+  - `verification/coq/PQCMigration.v` (WAL model)
+  - `verification/framac/wp_pqc_wal.c` (asserts safety by construction)
+- Function(s): TLA `Recover` (and crash steps), Coq `apply_wal_record`/`wal_replay`
+- Layer: Protocol logic / formal model
+
+---
+
+### 3. Vulnerability Description
+Invariant required: **after crash+recovery, the system must not (a) falsely believe classical key material is destroyed when it can be resurrected from durable storage, nor (b) falsely rely on classical material that was erased.**
+
+The TLA model uses `finalize_step` after a crash to decide whether erasure occurred, even though `finalize_step` is an in-memory progress variable that would not survive a crash. This is an implicit oracle. The Coq/Frama-C models similarly do not represent durable secret storage in a way that constrains “resurrection” vs “irrecoverable loss.”
+
+---
+
+### 4. Root Cause Analysis
+- Crash model does not faithfully model which state survives power loss (volatile vs durable).
+- No durable, monotonic marker for “classical secret erased” vs “classical secret still recoverable from keystore/WAL/backup.”
+- Safety is asserted by model structure rather than derived from realistic persistence semantics.
+
+---
+
+### 5. Attack Scenario
+- Initial state: system finalizing a key; classical secret is erased in RAM; WAL still says FINALIZING.
+- Attacker capabilities: can induce crashes (power kill, SIGKILL, OOM) and exploit partitions/replay.
+- Step-by-step:
+  1) Crash occurs after erasure but before WAL commit to PQC_ONLY.
+  2) Recovery replays WAL to FINALIZING but cannot *durably* know whether classical private key is gone.
+  3) System either:
+     - attempts rollback / legacy signing and fails (availability failure), or
+     - reloads classical secret from a durable keystore/backup to proceed (security regression).
+- Resulting system violation: either **irrecoverable outage** or **violation of key-destruction guarantees**.
+
+---
+
+### 6. Proof of Concept (PoC)
+Protocol-level trace (crash injection) is sufficient; the current specs do not rule it out because they do not model the durable secret store and rely on volatile progress state.
+
+---
+
+### 7. Impact Analysis
+- Confidentiality impact: risk of reintroducing classical secrets post-“erasure.”
+- Integrity violation: migration state can lie about destruction/compliance.
+- Availability: repeated crash window can brick keys or force permanent degraded mode.
+
+---
+
+### 8. Formal Security Impact
+- Invalidates: claimed “classical key destruction” and “safe degradation” unless a durable recovery marker is formally enforced.
+- Undermines audit/compliance statements derived from “irreversible finalization.”
+
+---
+
+### 9. Mitigation / Fix
+- Make erasure state **durable and monotonic**:
+  - WAL record `ERASING_CLASSICAL` before erasure; WAL record `CLASSICAL_ERASED` after erasure; only then `PQC_ONLY`.
+  - Recovery logic must treat `CLASSICAL_ERASED` as irreversible and never reload classical private material.
+- Explicitly model the keystore and what bytes persist; ensure no path exists that restores classical private bytes after erasure.
+
+---
+
+### 10. Verification Strategy
+- Update TLA to eliminate reliance on volatile variables post-crash; explicitly model durable keystore contents.
+- Model-check crash at every step with an adversary that can crash repeatedly.
+- Add integration fault-injection tests (fsync discipline + `SIGKILL` at step boundaries) once an implementation exists.
+

--- a/audit/SYSTEMIC_RISK_ASSESSMENT.md
+++ b/audit/SYSTEMIC_RISK_ASSESSMENT.md
@@ -1,0 +1,24 @@
+# SYSTEMIC RISK ASSESSMENT
+
+## SAFE under adversarial deployment?
+No.
+
+## Primary failure mode (design vs implementation vs assumptions)
+- Implementation failures: domain separation is bypassable (collision + truncation), C key lifecycle leaks, and FFI wrappers expose use-after-free via pointer aliasing.
+- Design failures: OR-mode hybrid verification collapses security to the weakest component and enables signature stripping/downgrade acceptance.
+- Assumption/assurance failures: the formal artifacts are not tied to the shipped implementation and include vacuous models/misstated theorems; they do not substantiate “mathematically verified” deployment claims.
+
+## Most dangerous hidden failure mode
+False assurance: “formal verification” branding and “mathematical” language encourages high-threat deployments while critical authorization boundaries (domain separation and hybrid verification policy) are bypassable or degradable in practice.
+
+## Framework Coverage (NIST + IEEE)
+- Cryptographic Soundness: issues found (HIG-001, HIG-002, HIG-005)
+- Implementation Safety: issues found (HIG-003, HIG-004)
+- Protocol Invariants & State Machines: issues found (HIG-005, HIG-007)
+- Attack Surface Modeling (STRIDE): issues found (HIG-001, HIG-002, HIG-003, HIG-005)
+- Proof Integrity: issues found (HIG-006)
+- Composition Risks: issues found (HIG-001, HIG-005)
+- Operational Security: issues found (HIG-002, HIG-004, HIG-007)
+
+Side-channels (timing/cache): No exploitable issue found under adversarial analysis assumptions in the audited C wrapper logic beyond variable-time operations on non-secret inputs; OpenSSL/provider constant-time behavior is not established by these artifacts and would require dedicated microarchitectural testing.
+


### PR DESCRIPTION
Add a structured set of Markdown vulnerability reports under , one per issue (HIG-001..HIG-007), plus a
summarizing cross-cutting risks and assurance gaps.

Each report uses repository-relative paths suitable for GitHub review and captures classification, affected components, attack scenarios, PoCs, mitigations, and verification strategies under adversarial deployment assumptions.

Files added:
- audit/HIG-001-domain-separation-non-injective.md
- audit/HIG-002-crypto-downgrade-algorithm-agility.md
- audit/HIG-003-ffi-use-after-free-pointer-aliasing.md
- audit/HIG-004-key-lifecycle-leak-regeneration-overwrite.md
- audit/HIG-005-or-mode-hybrid-verification-downgrade.md
- audit/HIG-006-proof-integrity-gap-and-vacuous-models.md
- audit/HIG-007-erasure-before-wal-crash-semantics-gap.md
- audit/SYSTEMIC_RISK_ASSESSMENT.md